### PR TITLE
feat: create and update `integrations` records for Travelperk and BambooHR

### DIFF
--- a/apps/bamboohr/tasks.py
+++ b/apps/bamboohr/tasks.py
@@ -1,5 +1,7 @@
+import logging
 from apps.bamboohr.models import BambooHr
 from apps.fyle_hrms_mappings.models import DestinationAttribute
+from apps.integrations.models import Integration
 from apps.orgs.models import FyleCredential, Org
 from apps.users.helpers import PlatformConnector
 from fyle_employee_imports.bamboo_hr import BambooHrEmployeeImport
@@ -7,6 +9,10 @@ from bamboosdk.bamboohrsdk import BambooHrSDK
 from django_q.models import Schedule
 
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
+logger.level = logging.INFO
+
 
 def import_employees(org_id: int, is_incremental_sync: bool = False):
     """
@@ -85,3 +91,35 @@ def schedule_failure_emails_for_employees(org_id):
                 'next_run': datetime.now()
         }
     )
+
+def add_bamboo_hr_to_integrations(org):
+    logger.info(f'New integration record: Fyle BambooHR Integration (HRMS) | {org.fyle_org_id = } | {org.name = }')
+
+    Integration.objects.update_or_create(
+        org_id=org.fyle_org_id,
+        type='HRMS',
+        defaults={
+            'is_active': True,
+            'org_name': org.name,
+            'tpa_id': 'tpayrBcJzWAlx',
+            'tpa_name': 'Fyle BambooHR Integration'
+        }
+    )
+
+def deactivate_bamboo_hr_integration(org_id):
+    """
+    Deactivate the integration for the given org_id
+    """
+    try:
+        org = Org.objects.get(id=org_id)
+    except Org.DoesNotExist:
+        logger.error(f'Org with id {org_id} not found')
+
+    integration = Integration.objects.filter(org_id=org.fyle_org_id, type='HRMS').first()
+    if integration:
+        integration.is_active=False
+        integration.disconnected_at=datetime.now()
+        integration.save()
+        logger.info(f'Deactivated integration: Fyle BambooHR Integration (HRMS) | {org.fyle_org_id = } | {org.name = }')
+    else:
+        logger.error(f'Integration not found: Fyle BambooHR Integration (HRMS) | {org.fyle_org_id = } | {org.name = }')

--- a/apps/bamboohr/views.py
+++ b/apps/bamboohr/views.py
@@ -8,8 +8,9 @@ from rest_framework import generics
 from apps.orgs.models import Org
 from apps.bamboohr.models import BambooHr, BambooHrConfiguration
 from apps.bamboohr.serializers import BambooHrSerializer, BambooHrConfigurationSerializer
-from apps.bamboohr.tasks import delete_sync_employee_schedule
+from apps.bamboohr.tasks import add_bamboo_hr_to_integrations, deactivate_bamboo_hr_integration, delete_sync_employee_schedule
 
+from bamboosdk.exceptions import InvalidTokenError, NoPrivilegeError, NotFoundItemError
 from django_q.tasks import async_task
 
 logger = logging.getLogger(__name__)
@@ -88,13 +89,31 @@ class BambooHrConnection(generics.CreateAPIView):
     def post(self, request, *args, **kwargs):
         org = Org.objects.filter(id=kwargs['org_id']).first()
 
-        api_token = request.data['input']['api_token']
-        sub_domain = request.data['input']['subdomain']
+        try:
+            api_token = request.data['input']['api_token']
+            sub_domain = request.data['input']['subdomain']
+        except KeyError:
+            return Response(
+                data={
+                    "message": "API_TOKEN and SUB_DOMAIN are required"
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         logger.info('Bamboo HR Connection Request Payload | Content: {{api_token: {0}, sub_domain: {1}}}'.format(api_token, sub_domain))
 
         bamboohrsdk = BambooHrSDK(api_token=api_token, sub_domain=sub_domain)
-        timeoff = bamboohrsdk.time_off.get()
+
+        try:
+            timeoff = bamboohrsdk.time_off.get()
+        except (NoPrivilegeError, NotFoundItemError, InvalidTokenError) as e:
+            return Response(
+                data = {
+                    'message': 'Invalid token'
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
         logger.info('Bamboo HR Connection Timeoff Response | Content: {0}'.format(timeoff))
         if timeoff.get('timeOffTypes', None):
             bamboohr, _ = BambooHr.objects.update_or_create(org=org, defaults={
@@ -102,10 +121,12 @@ class BambooHrConnection(generics.CreateAPIView):
                 'sub_domain': sub_domain
             })
 
+            add_bamboo_hr_to_integrations(org)
+
             return Response(
-            data="BambooHr is connected",
-            status=status.HTTP_200_OK
-        )
+                data="BambooHr is connected",
+                status=status.HTTP_200_OK
+            )
         else:
             return Response(
                 data = {
@@ -169,19 +190,22 @@ class DisconnectView(generics.CreateAPIView):
     def post(self, request, *args, **kwargs):
         try:
             bamboohr_queryset = BambooHr.objects.filter(org__id=kwargs['org_id'])
+            if bamboohr_queryset.count() == 0:
+                return Response(
+                    data = {
+                        'message': 'BambooHR connection does not exists for this org.'
+                    },
+                    status = status.HTTP_404_NOT_FOUND
+                )
+
             bamboohr_queryset.update(api_token=None, sub_domain=None)
             delete_sync_employee_schedule(org_id=kwargs['org_id'])
+            deactivate_bamboo_hr_integration(kwargs['org_id'])
             return Response(
                 data='Successfully Disconneted!',
                 status=status.HTTP_200_OK
             )
-        except BambooHr.DoesNotExist:
-            return Response(
-                data = {
-                    'message': 'BambooHR connection does not exists for this org.'
-                },
-                status = status.HTTP_404_NOT_FOUND
-            )
+
         except BambooHrConfiguration.DoesNotExist:
             return Response(
                 data={'message': 'BambooHr Configuration does not exist for this Workspace'},

--- a/apps/integrations/views.py
+++ b/apps/integrations/views.py
@@ -2,7 +2,7 @@ import logging
 from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.views import status
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, ParseError, APIException
 
 from .actions import get_integration, get_org_id_and_name_from_access_token
 from .models import Integration
@@ -14,7 +14,7 @@ logger.level = logging.INFO
 
 
 
-class IntegrationsView(generics.ListCreateAPIView):
+class IntegrationsView(generics.ListCreateAPIView, generics.UpdateAPIView):
     permission_classes = []
     authentication_classes = []
     pagination_class = None
@@ -22,6 +22,14 @@ class IntegrationsView(generics.ListCreateAPIView):
     pagination_class = None
     queryset = Integration.objects.filter(is_active=True, is_beta=True).order_by('-updated_at')
     filterset_fields = {'type': {'exact'}, 'org_id': {'exact'}}
+
+    def get_object(self):
+        queryset = self.get_queryset()
+        instance = queryset.get(
+            org_id=self.request.data['org_id'],
+            tpa_name=self.request.data['tpa_name']
+        )
+        return instance
 
     def get(self, request, *args, **kwargs):
         # This block is for authenticating the user
@@ -40,6 +48,33 @@ class IntegrationsView(generics.ListCreateAPIView):
         except Exception as error:
             logger.info(error)
             raise AuthenticationFailed('Invalid access token')
+
+
+    def patch(self, request, *args, **kwargs):
+        if request.data.get('tpa_name', None) is None:
+            raise ParseError('tpa_name is required')
+
+        http_authorization = self.request.META.get('HTTP_AUTHORIZATION')
+        if not http_authorization:
+            raise AuthenticationFailed('No access token provided')
+
+        access_token = http_authorization.split(' ')[1]
+
+        try:
+            org_id = get_org_id_and_name_from_access_token(access_token)['id']
+            request.data['org_id'] = org_id
+        except Exception as error:
+            logger.info(error)
+            raise AuthenticationFailed('Invalid access token')
+        
+        try:
+            return super().patch(request, *args, **kwargs)
+        except Integration.DoesNotExist as error:
+            logger.info(error)
+            raise ParseError('Integration is inactive or does not exist')
+        except Exception as error:
+            logger.info(error)
+            raise APIException('Something went wrong')
 
     def perform_create(self, serializer):
         try:

--- a/apps/travelperk/actions.py
+++ b/apps/travelperk/actions.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from fyle.platform import Platform
 
+from apps.integrations.models import Integration
 from apps.orgs.exceptions import handle_fyle_exceptions
 from apps.travelperk.models import (
     Invoice, 
@@ -291,3 +292,36 @@ def create_expense_in_fyle(org_id: str, invoice: Invoice, invoice_lineitems: Inv
         create_expense_against_employee(org_id, invoice, invoice_lineitems, profile_mapping.user_role, advanced_settings)
     else:
         create_expense_in_fyle_v2(org_id, invoice, invoice_lineitems)
+
+def add_travelperk_to_integrations(org_id):
+    org = Org.objects.get(id=org_id)
+    logger.info(f'New integration record: Fyle TravelPerk Integration (TRAVEL) | {org.fyle_org_id = } | {org.name = }')
+
+    Integration.objects.update_or_create(
+        org_id=org.fyle_org_id,
+        type='TRAVEL',
+        defaults={
+            'is_active': True,
+            'org_name': org.name,
+            'tpa_id': 'tpayrBcJzWAlx',
+            'tpa_name': 'Fyle TravelPerk Integration'
+        }
+    )
+
+def deactivate_travelperk_integration(org_id):
+    """
+    Deactivate the integration for the given org_id
+    """
+    try:
+        org = Org.objects.get(id=org_id)
+    except Org.DoesNotExist:
+        logger.error(f'Org with id {org_id} not found')
+
+    integration = Integration.objects.filter(org_id=org.fyle_org_id, type='TRAVEL').first()
+    if integration:
+        integration.is_active=False
+        integration.disconnected_at=datetime.now()
+        integration.save()
+        logger.info(f'Deactivated integration: Fyle TravelPerk Integration (TRAVEL) | {org.fyle_org_id = } | {org.name = }')
+    else:
+        logger.error(f'Integration not found: Fyle TravelPerk Integration (TRAVEL) | {org.fyle_org_id = } | {org.name = }')

--- a/apps/travelperk/serializers.py
+++ b/apps/travelperk/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from apps.travelperk.actions import add_travelperk_to_integrations
 from apps.travelperk.models import TravelPerk, InvoiceLineItem
 from apps.travelperk.connector import TravelperkConnector
 from apps.travelperk.models import (
@@ -75,6 +76,7 @@ class TravelperkAdvancedSettingSerializer(serializers.ModelSerializer):
         if travelperk.onboarding_state == 'ADVANCED_SETTINGS':
             travelperk.onboarding_state = 'COMPLETE'
             travelperk.save()
+            add_travelperk_to_integrations(org_id)
 
         return advanced_setting
 

--- a/apps/travelperk/views.py
+++ b/apps/travelperk/views.py
@@ -10,6 +10,7 @@ from django.db import transaction
 from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.views import status
+from apps.travelperk.actions import deactivate_travelperk_integration
 from django_q.tasks import async_task
 
 from admin_settings.utils import LookupFieldMixin
@@ -75,6 +76,7 @@ class DisconnectTravelperkView(generics.CreateAPIView):
             travelperk.webhook_subscription_id = None
             travelperk.is_travelperk_connected = False
             travelperk.save()
+            deactivate_travelperk_integration(kwargs['org_id'])
 
             return Response(
                 data={'message': 'disconnected successfully'},

--- a/scripts/python/backfill_integrations_records.py
+++ b/scripts/python/backfill_integrations_records.py
@@ -1,0 +1,42 @@
+from apps.bamboohr.models import BambooHr
+from apps.integrations.models import Integration
+from apps.travelperk.models import TravelPerk
+
+# Expected output:
+# travelperk_created = 24
+# bamboo_created = 44
+
+
+travelperk_created = 0
+for tp_object in TravelPerk.objects.all():
+    _, created = Integration.objects.update_or_create(
+        org_id=tp_object.org.id,
+        type='TRAVEL',
+        defaults={
+            'is_active': True,
+            'org_name': tp_object.org.name,
+            'tpa_id': 'tpayrBcJzWAlx',
+            'tpa_name': 'Fyle TravelPerk Integration',
+            'connected_at': tp_object.created_at
+        }
+    )
+    travelperk_created += created
+
+print(f'{travelperk_created = }')
+
+bamboo_created = 0
+for bamboo_object in BambooHr.objects.all():
+    _, created = Integration.objects.update_or_create(
+        org_id=bamboo_object.org.id,
+        type='TRAVEL',
+        defaults={
+            'is_active': True,
+            'org_name': bamboo_object.org.name,
+            'tpa_id': 'tpayrBcJzWAlx',
+            'tpa_name': 'Fyle BambooHR Integration',
+            'connected_at': bamboo_object.created_at
+        }
+    )
+    bamboo_created += created
+
+print(f'{bamboo_created = }')

--- a/tests/test_bamboohr/fixtures.py
+++ b/tests/test_bamboohr/fixtures.py
@@ -1,31 +1,57 @@
 fixture = {
-    'bamboohr': {
-       "id":1,
-       "folder_id":"1231",
-       "package_id":"1231",
-       "api_token":"seofihsdofighsodifghspdiof",
-       "sub_domain":"dummy",
-       "webhook_id": "123",
-       "private_key": "123",
-       "created_at":"2022-11-29T15:39:49.221955Z",
-       "updated_at":"2022-11-29T15:41:59.535831Z",
-       "org":1,
-       "employee_exported_at": "2022-11-29T15:39:49.221955Z",
-       "is_credentials_expired": False,
+   'bamboohr': {
+      "id":1,
+      "folder_id":"1231",
+      "package_id":"1231",
+      "api_token":"seofihsdofighsodifghspdiof",
+      "sub_domain":"dummy",
+      "webhook_id": "123",
+      "private_key": "123",
+      "created_at":"2022-11-29T15:39:49.221955Z",
+      "updated_at":"2022-11-29T15:41:59.535831Z",
+      "org":1,
+      "employee_exported_at": "2022-11-29T15:39:49.221955Z",
+      "is_credentials_expired": False,
+   },
+   "configurations": {
+      "id":1,
+      "org": None,
+      "recipe_id": None,
+      "recipe_data": None,
+      "recipe_status": False,
+      "additional_email_options":[{
+         "name":"Nilsh",
+         "email":"dfoisdfoh@gmail.com"
+      }],
+      "emails_selected":[
+         "ni12lesh[amt1212@gmail.in",
+         "ashwin.t@fyle.in"
+      ]
+   },
+
+   "bamboo_connection": {
+      'input': {
+         'api_token': 'sample_token',
+         'subdomain': 'somesubdomain'
+      }
     },
-    "configurations": {
-           "id":1,
-           "org": None,
-           "recipe_id": None,
-           "recipe_data": None,
-           "recipe_status": False,
-           "additional_email_options":[{
-              "name":"Nilsh",
-              "email":"dfoisdfoh@gmail.com"
-           }],
-           "emails_selected":[
-              "ni12lesh[amt1212@gmail.in",
-              "ashwin.t@fyle.in"
-           ]
-        },
+
+   "bamboo_connection_invalid_payload": {
+      'input': {
+         'api_token': 'sample_token',
+      }
+    },
+
+    "integrations_response": {
+        "org_id": "orTwovfDpEYc",
+        "org_name": "Test org",
+        "tpa_id": "tpayrBcJzWAlx",
+        "tpa_name": "Fyle BambooHR Integration",
+        "type": "HRMS",
+        "is_active": True,
+        "is_beta": True,
+        "connected_at": "2025-01-09T10:08:20.434443Z",
+        "disconnected_at": None,
+        "updated_at": "2025-01-09T10:08:20.434443Z"
+    }
 }

--- a/tests/test_integrations/fixture.py
+++ b/tests/test_integrations/fixture.py
@@ -19,6 +19,37 @@ post_integration_accounting = {
     'connected_at': '2023-08-29T11:21:13.840713Z'
 }
 
+post_integration_accounting_2 = {
+    'tpa_id': 'tpasample_id1',
+    'tpa_name': 'Fyle Some Other Integration',
+    'type': 'ACCOUNTING',
+    'is_active': True,
+    'connected_at': '2025-01-22T11:21:13.840713Z'
+}
+
+
+patch_integration = {
+    'tpa_name': 'Fyle QuickBooks Online Integration',
+    'errors_count': 12,
+    'is_token_expired': False
+}
+
+patch_integration_partial = {
+    'tpa_name': 'Fyle QuickBooks Online Integration',
+    'is_token_expired': True
+}
+
+patch_integration_invalid_tpa_name = {
+    'tpa_name': 'Very Invalid TPA Name',
+    'errors_count': 12,
+    'is_token_expired': False
+}
+
+patch_integration_no_tpa_name = {
+    'errors_count': 12,
+    'is_token_expired': False
+}
+
 post_integration_hrms = {
     'tpa_id': 'tpa129sjcjkjx',
     'tpa_name': 'Fyle HRMS',

--- a/tests/test_integrations/test_views.py
+++ b/tests/test_integrations/test_views.py
@@ -1,8 +1,9 @@
 import json
 
+from apps.integrations.models import Integration
 import pytest
 from django.urls import reverse
-from .fixture import mock_post_new_integration_response, post_integration_accounting, post_integration_hrms
+from .fixture import post_integration_accounting, post_integration_accounting_2, post_integration_hrms, patch_integration_no_tpa_name, patch_integration, patch_integration_invalid_tpa_name, patch_integration_partial
 
 
 @pytest.mark.django_db(databases=['default'])
@@ -70,6 +71,8 @@ def test_integrations_view_post(api_client, mocker, access_token):
     assert response['is_beta'] == True
     assert response['disconnected_at'] == None
 
+    accounting_integration_id = response['id']
+
     response = api_client.post(url, post_integration_hrms)
     assert response.status_code == 201
 
@@ -80,6 +83,27 @@ def test_integrations_view_post(api_client, mocker, access_token):
     assert response['tpa_name'] == post_integration_hrms['tpa_name']
     assert response['type'] == post_integration_hrms['type']
     assert response['is_active'] == post_integration_hrms['is_active']
+    assert response['is_beta'] == True
+    assert response['disconnected_at'] == None
+
+
+    # A second POST with the same org_id and type should update the record
+
+    response = api_client.post(url, post_integration_accounting_2)
+    assert response.status_code == 201
+
+    response = json.loads(response.content)
+
+    # Check if a record was updated, and no new record was inserted
+    assert response['id'] == accounting_integration_id
+    assert Integration.objects.filter(org_id=dummy_org_id).count() == 2
+
+    # Check if the updates went through
+    assert response['org_id'] == dummy_org_id
+    assert response['tpa_id'] == post_integration_accounting_2['tpa_id']
+    assert response['tpa_name'] == post_integration_accounting_2['tpa_name']
+    assert response['type'] == post_integration_accounting_2['type']
+    assert response['is_active'] == post_integration_accounting_2['is_active']
     assert response['is_beta'] == True
     assert response['disconnected_at'] == None
 
@@ -150,6 +174,9 @@ def test_integrations_view_invalid_access_token(api_client):
     response = api_client.post(url, post_integration_accounting)
     assert response.status_code == 403
 
+    response = api_client.patch(url, post_integration_accounting)
+    assert response.status_code == 403
+
 
 @pytest.mark.django_db(databases=['default'])
 def test_integrations_view_mark_inactive_post(api_client, mocker, access_token, create_integrations):
@@ -194,3 +221,48 @@ def test_integrations_view_mark_inactive_post(api_client, mocker, access_token, 
 
     response = json.loads(response.content)
     assert response['is_active'] == True
+
+
+@pytest.mark.django_db(databases=['default'])
+def test_integrations_view_patch(api_client, mocker, access_token):
+    """
+    Test the PATCH API of Integrations
+    """
+    dummy_org_id = 'or3P3xJ0603e'
+    mocker.patch(
+        'apps.integrations.views.get_org_id_and_name_from_access_token',
+        return_value={"id":dummy_org_id, "name":"Dummy Org"}
+    )
+    mocker.patch(
+        'apps.integrations.actions.get_cluster_domain',
+        return_value='https://hehe.fyle.tech'
+    )
+
+    url = reverse('integrations:integrations')
+
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(access_token))
+
+
+    response = api_client.patch(url, patch_integration_no_tpa_name)
+    assert response.status_code == 400, 'Should not be able to PATCH without a tpa_name'
+
+    response = api_client.patch(url, patch_integration_invalid_tpa_name)
+    assert response.status_code == 400, 'Should not be able to PATCH with an invalid tpa_name'
+
+    # Update two fields
+    response = api_client.patch(url, patch_integration)
+    assert response.status_code == 200, 'Valid PATCH request should be successful'
+
+    response = json.loads(response.content)
+    assert response['tpa_name'] == patch_integration['tpa_name']
+    assert response['errors_count'] == patch_integration['errors_count']
+    assert response['is_token_expired'] == patch_integration['is_token_expired']
+
+    # Update one field, leaving the other as it is
+    response = api_client.patch(url, patch_integration_partial)
+    assert response.status_code == 200, 'Valid PATCH request should be successful'
+
+    response = json.loads(response.content)
+    assert response['tpa_name'] == patch_integration_partial['tpa_name']
+    assert response['is_token_expired'] == patch_integration_partial['is_token_expired']
+    assert response['errors_count'] == patch_integration['errors_count']

--- a/tests/test_travelperk/fixtures.py
+++ b/tests/test_travelperk/fixtures.py
@@ -110,5 +110,17 @@ fixture = {
             }
         },
         "org": 360
+    },
+    "integrations_response": {
+        "org_id": "orTwovfDpEYc",
+        "org_name": "Test org",
+        "tpa_id": "tpayrBcJzWAlx",
+        "tpa_name": "Fyle TravelPerk Integration",
+        "type": "TRAVEL",
+        "is_active": True,
+        "is_beta": True,
+        "connected_at": "2025-01-09T10:08:20.434443Z",
+        "disconnected_at": None,
+        "updated_at": "2025-01-09T10:08:20.434443Z"
     }
 }


### PR DESCRIPTION
- Update `integrations` table on Travelperk / BambooHR connection and disconnection
- Fix: login attempts with expired API tokens returning 500
- Add PATCH support to the `/integrations` endpoint: Lookup records by `org_id` and `tpa_name` and update one or more fields
- Add a script to backfill `integrations` table records for already existing TravelPerk and BambooHR connections
- Unit test all of the above

---

* test: POST and PATCH `/integrations/`

* test: bambooHR and travelperk - POST to integrations on connection (#232)

* test: bambooHR and travelperk - POST to integrations on connection

* feat: add a travelperk record to the integrations table on connection (#233)

* feat: add a travelperk record to the integrations table on connection

* feat: add a BambooHR record to the integrations table on connection (#234)

* feat: add a BambooHR record to the integrations table on connection

fix: return 400 on invalid login attempts

* feat: deactivate integration on BambooHR disconnect (#235)

* feat: deactivate integration on BambooHR disconnect

* refactor: update error messages

* feat: deactivate integration on TravelPerk disconnect (#236)

* feat: deactivate integration on TravelPerk disconnect

* feat: add PATCH support to partially update integration records (#237)

* feat: add PATCH support to partially update integration records

* feat: backfill integration records for BambooHR and TravelPerk (#238)