### PR TITLE
fix: failing patch requests

### DIFF
--- a/apps/integrations/serializers.py
+++ b/apps/integrations/serializers.py
@@ -26,7 +26,9 @@ class IntegrationSerializer(serializers.ModelSerializer):
                     'is_active': True,
                     'org_name': validated_data['org_name'],
                     'tpa_id': validated_data['tpa_id'],
-                    'tpa_name': validated_data['tpa_name']
+                    'tpa_name': validated_data['tpa_name'],
+                    'errors_count': 0,
+                    'is_token_expired': False
                 }
             )
         elif not validated_data['is_active']:

--- a/apps/integrations/views.py
+++ b/apps/integrations/views.py
@@ -62,7 +62,6 @@ class IntegrationsView(generics.ListCreateAPIView, generics.UpdateAPIView):
 
         try:
             org_id = get_org_id_and_name_from_access_token(access_token)['id']
-            request.data._mutable = True
             request.data['org_id'] = org_id
         except Exception as error:
             logger.info(error)

--- a/tests/test_integrations/test_views.py
+++ b/tests/test_integrations/test_views.py
@@ -251,14 +251,14 @@ def test_integrations_view_patch(api_client, mocker, access_token):
     api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(access_token))
 
 
-    response = api_client.patch(url, patch_integration_no_tpa_name)
+    response = api_client.patch(url,  json.dumps(patch_integration_no_tpa_name), content_type="application/json")
     assert response.status_code == 400, 'PATCH without a tpa_name should return 400'
 
-    response = api_client.patch(url, patch_integration_invalid_tpa_name)
+    response = api_client.patch(url,  json.dumps(patch_integration_invalid_tpa_name), content_type="application/json")
     assert response.status_code == 400, 'PATCH with an invalid tpa_name should return 400'
 
     # Update two fields
-    response = api_client.patch(url, patch_integration)
+    response = api_client.patch(url,  json.dumps(patch_integration), content_type="application/json")
     assert response.status_code == 200, 'Valid PATCH request should be successful'
 
     response = json.loads(response.content)
@@ -267,7 +267,7 @@ def test_integrations_view_patch(api_client, mocker, access_token):
     assert response['is_token_expired'] == patch_integration['is_token_expired']
 
     # Update one field, leaving the other as it is
-    response = api_client.patch(url, patch_integration_partial)
+    response = api_client.patch(url, json.dumps(patch_integration_partial), content_type="application/json")
     assert response.status_code == 200, 'Valid PATCH request should be successful'
 
     response = json.loads(response.content)


### PR DESCRIPTION
`request.data` is a regular dict for `application/json`. `request.data._mutable` is not required.

## Clickup
https://app.clickup.com/t/86cxhfhdp